### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -9,10 +9,10 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v3.3.0"
         },
         {
-          "uses": "codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b",
+          "uses": "codacy/codacy-analysis-cli-action@v4.2.0",
           "with": {
             "format": "sarif",
             "gh-code-scanning-compat": true,
@@ -23,7 +23,7 @@
           }
         },
         {
-          "uses": "github/codeql-action/upload-sarif@v2",
+          "uses": "github/codeql-action/upload-sarif@codeql-bundle-20230105",
           "with": {
             "sarif_file": "results.sarif"
           }


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230105](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230105)** on 2023-01-06T15:03:08Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[codacy/codacy-analysis-cli-action](https://github.com/codacy/codacy-analysis-cli-action)** published a new release **[v4.2.0](https://github.com/codacy/codacy-analysis-cli-action/releases/tag/v4.2.0)** on 2022-09-20T16:18:43Z
