### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@
           }
         },
         {
-          "uses": "github/codeql-action/autobuild@v2"
+          "uses": "github/codeql-action/autobuild@codeql-bundle-20230105"
         },
         {
           "uses": "github/codeql-action/analyze@codeql-bundle-20230105",


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230105](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230105)** on 2023-01-06T15:03:08Z
